### PR TITLE
站kha加統一編號kah公司全名

### DIFF
--- a/src/網站/頁腳.jsx
+++ b/src/網站/頁腳.jsx
@@ -12,6 +12,7 @@ class 頁腳 extends Component {
   render() {
     const { paths } = this.props;
     const { home, sanphin, tsuanan, suisiann, siongkuan, lianlok } = paths;
+    const ni = new Date().getFullYear();
 
     return (
       <Segment inverted vertical>
@@ -21,9 +22,14 @@ class 頁腳 extends Component {
                 <Grid.Column width={4}>
                   <Header inverted as='h4' content='Tsih-tsiap' />
                   <List link inverted>
-                    <List.Item as='a'>ithuan@ithuan.tw</List.Item>
-                    <List.Item as='a'>04-8358062</List.Item>
-                    <List.Item as='a'>510001 員林市，中正路543巷3號</List.Item>
+                    <List.Item as='a'>
+                      <Icon name='envelope'/>ithuan@ithuan.tw</List.Item>
+                    <List.Item as='a'>
+                      <Icon name='phone'/>04-8358062
+                    </List.Item>
+                    <List.Item as='a'>
+                      <Icon name='map'/>510001 員林市，中正路543巷3號
+                    </List.Item>
                     <List.Item as='a' 
                         href="https://www.facebook.com/ithuan.tw/"
                         target="_blank" 
@@ -63,7 +69,10 @@ class 頁腳 extends Component {
          
           <Divider/>
           
-          <p style={{"textAlign":"center"}}>ÌTHUÂN KHOKI 意傳科技 © 2021</p>
+          <p style={{"textAlign":"center"}}>
+            版權所有 &copy; {ni} ÌTHUÂN KHOKI CO., LTD. 意傳科技有限公司 <br/>
+            統一編號 58020378
+          </p>
 
         </Container>
       </Segment>


### PR DESCRIPTION
## 狀況

>   稅籍登記規則
>   修正日期：民國111 年 08 月 08 日
>   第 4-1 條、
>  營業人專營或兼營以網路平臺、行動裝置應用程式或其他電子方式銷售貨物或勞務，應於其網路銷售頁面及相關交易應用軟體或程式之明顯位置清楚揭露其營利事業統一編號及前條第一項第一款規定之名稱。

## 做法

統一編號加tī上尾，公司名寫全名。

電腦版

![image](https://user-images.githubusercontent.com/6355592/217145807-2d17d3ac-07e3-4868-933c-5be9cf541f37.png)

手機仔版

![image](https://user-images.githubusercontent.com/6355592/217145747-ef7a3f53-b2bb-4f11-ae95-03286f64dd0d.png)
